### PR TITLE
Added .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__
+datasets/
+models/__pycache__
+runs
+utils/__pycache__
+utils/wandb_logging/__pycache__
+wandb


### PR DESCRIPTION
I added a .gitignore file so that every time we run `python train.py` and then use `git status`, it doesn't show a lot of unnecessary files. Specifically I added the following lines in the .gitignore
```__pycache__
datasets/
models/__pycache__
runs
utils/__pycache__
utils/wandb_logging/__pycache__
wandb
```