### PR TITLE
Fix dtype issues and update dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 # base ----------------------------------------
 matplotlib>=3.2.2
-numpy>=1.18.5
+numpy==1.23.0
 opencv-python>=4.1.2
 Pillow
 PyYAML>=5.3.1

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -408,7 +408,7 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
                 x[:, 0] = 0
 
         n = len(shapes)  # number of images
-        bi = np.floor(np.arange(n) / batch_size).astype(np.int)  # batch index
+        bi = np.floor(np.arange(n) / batch_size).astype(np.int32)  # batch index
         nb = bi[-1] + 1  # number of batches
         self.batch = bi  # batch index of image
         self.n = n
@@ -436,7 +436,7 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
                 elif mini > 1:
                     shapes[i] = [1, 1 / mini]
 
-            self.batch_shapes = np.ceil(np.array(shapes) * img_size / stride + pad).astype(np.int) * stride
+            self.batch_shapes = np.ceil(np.array(shapes) * img_size / stride + pad).astype(np.int32) * stride
 
         # Cache images into memory for faster training (WARNING: large datasets may exceed system RAM)
         self.imgs = [None] * n
@@ -1034,7 +1034,7 @@ def extract_boxes(path='../coco128/'):  # from utils.datasets import *; extract_
                     b = x[1:] * [w, h, w, h]  # box
                     # b[2:] = b[2:].max()  # rectangle to square
                     b[2:] = b[2:] * 1.2 + 3  # pad
-                    b = xywh2xyxy(b.reshape(-1, 4)).ravel().astype(np.int)
+                    b = xywh2xyxy(b.reshape(-1, 4)).ravel().astype(np.int32)
 
                     b[[0, 2]] = np.clip(b[[0, 2]], 0, w)  # clip boxes outside of image
                     b[[1, 3]] = np.clip(b[[1, 3]], 0, h)

--- a/utils/loss.py
+++ b/utils/loss.py
@@ -208,7 +208,9 @@ class ComputeLoss:
 
             # Append
             a = t[:, 6].long()  # anchor indices
-            indices.append((b, a, gj.clamp_(0, gain[3] - 1), gi.clamp_(0, gain[2] - 1)))  # image, anchor, grid indices
+            gj = gj.long().clamp_(0, int(gain[3] - 1))
+            gi = gi.long().clamp_(0, int(gain[2] - 1))
+            indices.append((b, a, gj, gi))
             tbox.append(torch.cat((gxy - gij, gwh), 1))  # box
             anch.append(anchors[a])  # anchors
             tcls.append(c)  # class


### PR DESCRIPTION
This MR includes three main updates to improve type compatibility and prevent runtime errors:

1. **Update `datasets.py`**
   Replace deprecated `np.int` with `np.int32` for explicit dtype specification.

2. **Update `loss.py`**
   Fix `RuntimeError` caused by casting issues: ensure result type `Float` is properly handled instead of trying to cast to `long int`.

3. **Update `requirements.txt`**
   Modify dependencies to prevent the `TypeError: No loop matching the specified signature and casting was found for ufunc greater` error.